### PR TITLE
fix Caesercipher Calculator Issue #31

### DIFF
--- a/CaeserCipher_Calculator/caeser.js
+++ b/CaeserCipher_Calculator/caeser.js
@@ -27,11 +27,12 @@ var alphabet = "abcdefghijklmnopqrstuvwxyz";
         }
       }
 
-      $('#finish').val(cipherFinish);
+      // $('#finish').val(cipherFinish);
+      document.getElementById('finish').value = cipherFinish;
     }
 //in the last form row we will get the required output which id is finish(in HTML file)
     $(document).ready(function () {
-      $('#cypher').keypress(function () {
+      $('#cypher').keydown(function () {
         setTimeout(function () { runCipher(); }, 20);
       });
       $('#cypher').blur(function () {

--- a/CaeserCipher_Calculator/caeser.js
+++ b/CaeserCipher_Calculator/caeser.js
@@ -34,16 +34,18 @@ var alphabet = "abcdefghijklmnopqrstuvwxyz";
     // $(document).ready(function () {
     document.addEventListener("DOMContentLoaded", () => {
       // $('#cypher').keydown(function () {
-      document.getElementById('cypher').keydown(function () {
+      document.getElementById('cypher').addEventListener('click', (function () {
         setTimeout(function () { runCipher(); }, 20);
-      });
+      }));
       // $('#cypher').blur(function () {
-      document.getElementById('cypher').blur(function () {
+      document.getElementById('cypher').addEventListener('blur', (function () {
         runCipher();
-      });
+      }));
       // $('#offset').change(function () {
-      document.getElementById('offset').change(function () {
+      document.getElementById('offset').addEventListener('change', (function () {
         setTimeout(runCipher(), 20);
-      });
-
+      }));
+      document.getElementById('finish').addEventListener('click', (function () {
+        setTimeout(function () { runCipher(); }, 20);
+      }));
     });

--- a/CaeserCipher_Calculator/caeser.js
+++ b/CaeserCipher_Calculator/caeser.js
@@ -3,8 +3,10 @@ var alphabet = "abcdefghijklmnopqrstuvwxyz";
     var fullAlphabet = alphabet + alphabet + alphabet;
 //fullAlphabet =if user provides key more then 26,for that purpose the concatentaion of alphabet is done.
     function runCipher() {
-      var cipherText = $('#cypher').val();
-      var cipherOffset = $('#offset').val();
+      // var cipherText = $('#cypher').val();
+      var cipherText = document.getElementById('cypher').value
+      // var cipherOffset = $('#offset').val();
+      var cipherOffset = document.getElementById('offset').value
       cipherOffset = (cipherOffset % alphabet.length);
       var cipherFinish = '';
 

--- a/CaeserCipher_Calculator/caeser.js
+++ b/CaeserCipher_Calculator/caeser.js
@@ -33,13 +33,16 @@ var alphabet = "abcdefghijklmnopqrstuvwxyz";
 //in the last form row we will get the required output which id is finish(in HTML file)
     // $(document).ready(function () {
     document.addEventListener("DOMContentLoaded", () => {
-      $('#cypher').keydown(function () {
+      // $('#cypher').keydown(function () {
+      document.getElementById('cypher').keydown(function () {
         setTimeout(function () { runCipher(); }, 20);
       });
-      $('#cypher').blur(function () {
+      // $('#cypher').blur(function () {
+      document.getElementById('cypher').blur(function () {
         runCipher();
       });
-      $('#offset').change(function () {
+      // $('#offset').change(function () {
+      document.getElementById('offset').change(function () {
         setTimeout(runCipher(), 20);
       });
 

--- a/CaeserCipher_Calculator/caeser.js
+++ b/CaeserCipher_Calculator/caeser.js
@@ -31,7 +31,8 @@ var alphabet = "abcdefghijklmnopqrstuvwxyz";
       document.getElementById('finish').value = cipherFinish;
     }
 //in the last form row we will get the required output which id is finish(in HTML file)
-    $(document).ready(function () {
+    // $(document).ready(function () {
+    document.addEventListener("DOMContentLoaded", () => {
       $('#cypher').keydown(function () {
         setTimeout(function () { runCipher(); }, 20);
       });

--- a/CaeserCipher_Calculator/caesercipher.html
+++ b/CaeserCipher_Calculator/caesercipher.html
@@ -38,7 +38,7 @@
           <br />
           <br />
           Finish:
-          <input type="text" id="finish" placeholder="Click here to get Ciphertext" readonly/>
+          <input type="text" id="finish" placeholder="Click here to get Ciphertext" />
           <!-- After clicking in this box we will get the required output -->
           <br />
           <br />

--- a/CaeserCipher_Calculator/caesercipher.html
+++ b/CaeserCipher_Calculator/caesercipher.html
@@ -38,7 +38,7 @@
           <br />
           <br />
           Finish:
-          <input type="text" id="finish" placeholder="Click here to get Ciphertext" />
+          <input type="text" id="finish" placeholder="Click here to get Ciphertext" readonly/>
           <!-- After clicking in this box we will get the required output -->
           <br />
           <br />


### PR DESCRIPTION
Linked Issue
#31 

After Working steps,
1)First give input text(Plaintext) 
2)Provide integer key 
3)Click in the last row and you will get the required output(encrypted text).

Steps to Reproduce:
4) Delete output(encrypted text)

Resulting Issue:
Output field stays blank unless Text input box is clicked.
Clicking anywhere else does not update the output field.

Description:
I added readonly attribute to Ciphertext input tag in caesercipher.html.
This prevents user from erasing the Ciphertext.

Extra Notes:
Due to errors, I changed $ to getElementById and used addEventListener events.
I added click event to call the function runCipher when output field is clicked as well.